### PR TITLE
Add TLS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea/
 node_modules/
 *.log
+./.env
+output/

--- a/app.js
+++ b/app.js
@@ -1,7 +1,9 @@
 'use strict';
 
 require("dotenv").config();
+const https = require("https");
 const cors = require("cors");
+const fs = require("fs");
 const express = require("express");
 const downloadManager = require("./utils/downloadManager");
 const { log } = require("./utils/logger");
@@ -12,11 +14,6 @@ app.use(cors());
 const portNumber = process.env.PORT || 3000;
 
 downloadManager.createDir(process.env.OUTPUT_FOLDER);
-
-app.listen(portNumber, function () {
-
-    log.info("Express server listening on port: " + portNumber);
-});
 
 app.use("/swdownloader/:id", function (req, res) {
 
@@ -42,3 +39,19 @@ app.use(function(req, res) {
     return res.status(404).send("Not found");
 });
 
+function serverStart(){
+    log.info("Express server listening on port: " + portNumber);
+}
+
+if(process.env.TLS_KEY_PATH && process.env.TLS_CERT_PATH &&
+    fs.existsSync(process.env.TLS_KEY_PATH) &&
+    fs.existsSync(process.env.TLS_CERT_PATH)){
+    let options = {
+        key: fs.readFileSync(process.env.TLS_KEY_PATH),
+        cert: fs.readFileSync(process.env.TLS_CERT_PATH)
+    }
+
+    https.createServer(options, app).listen(portNumber, serverStart);
+}else{
+    app.listen(portNumber, serverStart);
+}

--- a/utils/downloadManager.js
+++ b/utils/downloadManager.js
@@ -4,6 +4,7 @@ const { JSDOM } = require("jsdom");
 const { log } = require("./logger");
 
 const dir = process.env.OUTPUT_FOLDER;
+const target = process.env.OUTPUT_XML_NAME;
 
 module.exports = {
 
@@ -83,7 +84,7 @@ module.exports = {
             process.chdir(dir);
         }
 
-        return await JSDOM.fromFile("bruh.txt", {contentType: "text/xml"})
+        return await JSDOM.fromFile(target, {contentType: "text/xml"})
             .then(dom => {
 
                 log.debug("Document parsed");
@@ -94,7 +95,7 @@ module.exports = {
                 xmlDoc.documentElement.appendChild(newChildNode);
 
                 // Note: XML header is removed
-                return fs.writeFile("map_list.txt", xmlDoc.documentElement.outerHTML, err => {
+                return fs.writeFile(target, xmlDoc.documentElement.outerHTML, err => {
 
                     if (err)
                         return err;


### PR DESCRIPTION
Experimental TLS support via node's HTTPS module
Use the TLS_KEY_PATH and TLS_CERT_PATH in .env